### PR TITLE
Remove global NEW badge from sidebar

### DIFF
--- a/src/app/layouts/full/sidebar/nav-item/nav-item.component.html
+++ b/src/app/layouts/full/sidebar/nav-item/nav-item.component.html
@@ -12,8 +12,6 @@
     }" class="menu-list-item">
     <span class="iconify routeIcon" matListItemIcon [attr.data-icon]="item.iconName"></span>
     <span class="hide-menu">{{ item.displayName }}</span>
-    <span class="bg-light-secondary f-w-500 item-chip p-x-8 p-y-4 rounded-pill text-secondary">NEW</span>
-    
     @if(item.children && item.children.length) {
     <span class="arrow-icon" fxFlex>
       <span fxFlex></span>
@@ -36,7 +34,6 @@
   <mat-list-item (click)="openExternalLink(item.route)" class="menu-list-item" target="_blank">
     <span class="iconify routeIcon" matListItemIcon [attr.data-icon]="item.iconName"></span>
     <span class="hide-menu">{{ item.displayName }} </span>
-    <span class="bg-light-secondary f-w-500 item-chip p-x-8 p-y-4 rounded-pill text-secondary">NEW</span>
     @if(item.chip) {
     <span>
       <span class="{{ item.chipClass }} p-x-8 p-y-4 item-chip f-w-500 rounded-pill ">{{ item.chipContent }}</span>

--- a/src/app/layouts/full/sidebar/sidebar-data.ts
+++ b/src/app/layouts/full/sidebar/sidebar-data.ts
@@ -229,6 +229,9 @@ export const navItems: NavItem[] = [
     displayName: 'AI Tools',
     iconName: 'solar:robot-line-duotone',
     route: '#',
+    chip: true,
+    chipContent: 'NEW',
+    chipClass: 'bg-light-secondary text-secondary',
     children: [
       {
         displayName: 'Brand Summary Generator',


### PR DESCRIPTION
## Summary
- remove static `NEW` chip from sidebar nav-item template
- add chip data to `AI Tools` item so only it shows the NEW badge

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fc1626e60833180cef2dfafd6ae6a