### PR TITLE
Update logo path

### DIFF
--- a/src/app/layouts/full/sidebar/branding.component.ts
+++ b/src/app/layouts/full/sidebar/branding.component.ts
@@ -8,7 +8,7 @@ import { RouterModule } from '@angular/router';
   template: `
     <a [routerLink]="['/']">
       <img
-        src="./assets/images/logos/logo.svg"
+        src="http://202.65.155.117/images/logo.svg"
         class="align-middle m-2"
         alt="logo"
       />

--- a/src/app/pages/authentication/side-login/side-login.component.html
+++ b/src/app/pages/authentication/side-login/side-login.component.html
@@ -5,7 +5,11 @@
         <mat-card-content class="p-32">
           <div class="text-center">
             <a [routerLink]="['/dashboard']">
-              <img src="./assets/images/logos/logo.svg" class="align-middle m-2" alt="logo" />
+              <img
+                src="http://202.65.155.117/images/logo.svg"
+                class="align-middle m-2"
+                alt="logo"
+              />
             </a>
           </div>
 

--- a/src/app/pages/authentication/side-register/side-register.component.html
+++ b/src/app/pages/authentication/side-register/side-register.component.html
@@ -5,7 +5,11 @@
         <mat-card-content class="p-32">
           <div class="text-center">
             <a [routerLink]="['/dashboard']">
-              <img src="./assets/images/logos/logo.svg" class="align-middle m-2" alt="logo" />
+              <img
+                src="http://202.65.155.117/images/logo.svg"
+                class="align-middle m-2"
+                alt="logo"
+              />
             </a>
           </div>
 


### PR DESCRIPTION
## Summary
- use remote logo URL in the login page
- use remote logo URL in the register page
- use remote logo URL in the sidebar branding component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fcce664188331bec721690d48e3af