### PR TITLE
Fix Try Pro Version navigation

### DIFF
--- a/src/app/layouts/full/header/header.component.html
+++ b/src/app/layouts/full/header/header.component.html
@@ -20,7 +20,7 @@
 
   <span class="flex-1-auto"></span>
 
-  <a href="https://stratapps.com" target="_blank" mat-flat-button>Try Pro Version</a>
+  <button mat-flat-button routerLink="/home">Try Pro Version</button>
 
   <!-- --------------------------------------------------------------- -->
   <!-- profile Dropdown -->

--- a/src/app/public/public-routing.module.ts
+++ b/src/app/public/public-routing.module.ts
@@ -4,6 +4,7 @@ import { HomeComponent } from './home/home.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
+  { path: 'home', component: HomeComponent },
 ];
 
 @NgModule({


### PR DESCRIPTION
## Summary
- add route for HomeComponent in `PublicRoutingModule`
- navigate to home via routerLink on "Try Pro Version" button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fd3bbedc08331a02da90875c4d749