### PR TITLE
Fix sidebar navigation error

### DIFF
--- a/src/app/layouts/full/sidebar/nav-item/nav-item.component.ts
+++ b/src/app/layouts/full/sidebar/nav-item/nav-item.component.ts
@@ -43,7 +43,9 @@ export class AppNavItemComponent implements OnChanges {
 
   onItemSelected(item: NavItem) {
     if (!item.children || !item.children.length) {
-      this.router.navigate([item.route]);
+      if (item.route && item.route !== '#') {
+        this.router.navigate([item.route]);
+      }
     }
     if (item.children && item.children.length) {
       this.expanded = !this.expanded;


### PR DESCRIPTION
## Summary
- prevent navigation when sidebar items use `#` as route

## Testing
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fd49bf6bc8331981405d9abe36709