### PR TITLE
Fix route to load public module

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -10,8 +10,8 @@ export const routes: Routes = [
       {
         path: '',
         loadChildren: () =>
-          import('./public/public-routing.module').then(
-            (m) => m.PublicRoutingModule
+          import('./public/public.module').then(
+            (m) => m.PublicModule
           ),
       },
       {


### PR DESCRIPTION
## Summary
- load `PublicModule` to ensure header and footer components are registered

## Testing
- `npm test --silent --no-progress` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68807affff3c83319cf9775d96ab78e2