### PR TITLE
Fix standalone component errors

### DIFF
--- a/src/app/public/footer/footer.component.ts
+++ b/src/app/public/footer/footer.component.ts
@@ -2,7 +2,9 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-footer',
+  standalone: true,
   templateUrl: './footer.component.html',
-  styleUrls: ['./footer.component.scss']
+  styleUrls: ['./footer.component.scss'],
+  imports: [],
 })
 export class FooterComponent {}

--- a/src/app/public/header/header.component.ts
+++ b/src/app/public/header/header.component.ts
@@ -2,7 +2,9 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-header',
+  standalone: true,
   templateUrl: './header.component.html',
-  styleUrls: ['./header.component.scss']
+  styleUrls: ['./header.component.scss'],
+  imports: [],
 })
 export class HeaderComponent {}

--- a/src/app/public/home/home.component.ts
+++ b/src/app/public/home/home.component.ts
@@ -2,7 +2,9 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-home',
+  standalone: true,
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  styleUrls: ['./home.component.scss'],
+  imports: [],
 })
 export class HomeComponent {}

--- a/src/app/public/public.module.ts
+++ b/src/app/public/public.module.ts
@@ -8,8 +8,13 @@ import { HeaderComponent } from './header/header.component';
 import { FooterComponent } from './footer/footer.component';
 
 @NgModule({
-  declarations: [HomeComponent, HeaderComponent, FooterComponent],
-  imports: [CommonModule, RouterModule, PublicRoutingModule],
-  exports: [HomeComponent, HeaderComponent, FooterComponent],
+  imports: [
+    CommonModule,
+    RouterModule,
+    PublicRoutingModule,
+    HomeComponent,
+    HeaderComponent,
+    FooterComponent,
+  ],
 })
 export class PublicModule {}


### PR DESCRIPTION
## Summary
- convert header, footer and home components to standalone
- update `PublicModule` to import these standalone components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68807cc2f1dc8331b8d35b477a32fb59